### PR TITLE
Add documentation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,35 @@ Then you will see something like this:
 To get ruff automatically running install the following Plugin:
 - [VSCode - Ruff Plugin](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
 
-### Continuous Delivery
+
+## Testing
+
+A test suite of a typical Python package consists of unit, integration, and documentation tests
+(i.e. the code snippets embedded in the documentation),
+and it is truly important to write the tests to ensure that the code works as intended.
+
+The package template provides a minimal setup and the tests can be executed by invoking the Pytest runner:
+
+```shell
+pytest
+```
+
+The runner looks for tests in `src` and `tests` folders. On top of that, the Python code
+in the top-level `README.md` file is also executed, so we can demonstrate
+the most imporant functionality:
+
+```python
+>>> from project_name.foo import foo
+>>> foo()
+True
+
+```
+
+Since the documentation is executed, any code changes that can render the documentation obsolete can be picked up,
+prompting the documentation update.
+
+
+## Continuous Delivery
 You've done it, your package is at a state, where you want other to use it. Luckily, this repository features a CD-Pipeline,
 that will build and upload your packages to Pypi for you. To get the CD running you need to first follow these [instructions](https://docs.pypi.org/trusted-publishers/adding-a-publisher/). The pipeline uses [OIDC](https://openid.net/developers/how-connect-works/) to authenticate on Pypi. Make sure your [pyproject.toml](pyproject.toml) is set up correctly, which means take care of 2. of the section **Basic Setup**.
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ True
 ```
 
 Pytest will execute the snippet to ensure that invoking `foo()` in fact returns `True`.
-This is a way for documenting the typical use cases of the package.
-Since the documentation is executed, any code changes that render the documentation obsolete will be picked up, forcing a documentation update.
+
+The snippets in `README.md` can document the typical use cases of the package.
+Since the snippets are executed, any code changes that render the documentation obsolete will be picked up, forcing a documentation update.
 
 
 ## Continuous Delivery

--- a/README.md
+++ b/README.md
@@ -68,18 +68,18 @@ To get ruff automatically running install the following Plugin:
 ## Testing
 
 A test suite of a typical Python package consists of unit, integration, and documentation tests
-(i.e. the code snippets embedded in the documentation),
-and it is truly important to write the tests to ensure that the code works as intended.
+(i.e. the code snippets embedded in the documentation).
+It is important to write tests to ensure that your code works as intended.
 
-The package template provides a minimal setup and the tests can be executed by invoking the Pytest runner:
+This template provides a minimal setup for testing. Tests can be executed by invoking Pytest:
 
 ```shell
 pytest
 ```
 
 The runner looks for tests in `src` and `tests` folders. On top of that, the Python code
-in the top-level `README.md` file is also executed, so we can demonstrate
-the most imporant functionality:
+in the top-level `README.md` file is also executed.
+If `README.md` shows a snippet like this:
 
 ```python
 >>> from project_name.foo import foo
@@ -88,8 +88,9 @@ True
 
 ```
 
-Since the documentation is executed, any code changes that can render the documentation obsolete can be picked up,
-prompting the documentation update.
+Pytest will execute the snippet to ensure that invoking `foo()` in fact returns `True`.
+This is a way for documenting the typical use cases of the package.
+Since the documentation is executed, any code changes that render the documentation obsolete will be picked up, forcing a documentation update.
 
 
 ## Continuous Delivery

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 minversion = 7.0
 pythonpath = src
-testpaths =
-    tests
+testpaths = src tests README.md
+addopts = --doctest-modules --doctest-glob README.md

--- a/src/project_name/foo.py
+++ b/src/project_name/foo.py
@@ -3,5 +3,19 @@
 
 
 def foo():
-    """Its here, so the directory gets pushed. You are free to move it"""
+    """
+    Its here, so the directory gets pushed. You are free to move it.
+    
+    An example usage can be shown with a doctest:
+
+    >>> from project_name.foo import foo
+    >>> foo()
+    True
+
+    Doctests are included in the test suite and checked in the CI.
+    
+    Doctests can help users understand the code and adding a few examples may not be too hard.
+    However, it still takes time which is often a limiting resource.
+    Therefore, please use your judgment before documenting each and every function.
+    """
     return True

--- a/src/project_name/foo.py
+++ b/src/project_name/foo.py
@@ -3,19 +3,5 @@
 
 
 def foo():
-    """
-    Its here, so the directory gets pushed. You are free to move it.
-    
-    An example usage can be shown with a doctest:
-
-    >>> from project_name.foo import foo
-    >>> foo()
-    True
-
-    Doctests are included in the test suite and checked in the CI.
-    
-    Doctests can help users understand the code and adding a few examples may not be too hard.
-    However, it still takes time which is often a limiting resource.
-    Therefore, please use your judgment before documenting each and every function.
-    """
+    """Its here, so the directory gets pushed. You are free to move it"""
     return True


### PR DESCRIPTION
The PR sets up the documentation tests, adds a README section about tests, and an example doctest.

@SmartMonkey-git I also changed the heading level of Continuous Delivery to ##, it seemed more appropriate.